### PR TITLE
StagingApi: Remove sleep after creating a staging area

### DIFF
--- a/ingest/api/stagingapi.py
+++ b/ingest/api/stagingapi.py
@@ -69,8 +69,6 @@ class StagingApi:
 
         r = self.session.post(base, headers=self.header)
         r.raise_for_status()
-        self.logger.info('Waiting 10 seconds for IAM policy to take effect...'),
-        sleep(10)
         self.logger.info(f'Staging area created!: {base}')
         self.logger.info("Execution Time: %s seconds" % (time() - start_time))
         return r.json()


### PR DESCRIPTION
There is no longer a need to sleep after creating a staging area as:
(a) Upload incorporated the necessary sleep into its own API since Feb 2018, and
(b) Upload was rearchitected in Jun 2018 and no longer creates new IAM
    credentials during create