### PR TITLE
Validate sheet is in schema list

### DIFF
--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -140,10 +140,19 @@ class _ImportRegistry:
                 raise MultipleProjectsFound()
         type_map[metadata.object_id] = metadata
 
+    def add_submittables(self, metadata_entities):
+        for entity in metadata_entities:
+            self.add_submittable(entity)
+
     def add_module(self, metadata: MetadataEntity):
         if metadata.domain_type.lower() == 'project':
             metadata.object_id = self.project_id
         self._module_list.append(metadata)
+
+    def add_modules(self, metadata_entities, module_field_name):
+        for entity in metadata_entities:
+            entity.retain_content_fields(module_field_name)
+            self.add_module(entity)
 
     def import_modules(self):
         for module_entity in self._module_list:
@@ -197,12 +206,10 @@ class WorkbookImporter:
                         error["location"] = f'sheet={worksheet.title}'
                     workbook_errors.append(error)
 
-                for entity in metadata_entities:
-                    if worksheet.is_module_tab():
-                        entity.retain_content_fields(module_field_name)
-                        registry.add_module(entity)
-                    else:
-                        registry.add_submittable(entity)
+                if worksheet.is_module_tab():
+                    registry.add_modules(metadata_entities, module_field_name)
+                else:
+                    registry.add_submittables(metadata_entities)
             except Exception as e:
                 workbook_errors.append({"location": "File", "type": e.__class__.__name__, "detail": str(e)})
 

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -282,10 +282,12 @@ class NoProjectFound(Exception):
         message = f'The spreadsheet should be associated to a project.'
         super(NoProjectFound, self).__init__(message)
 
+
 class SheetNotFoundInSchemas(Exception):
     def __init__(self, sheet):
         message = f'The sheet {sheet} was not found in the list of schemas.'
         super(SheetNotFoundInSchemas, self).__init__(message)
+
 
 class SchemaRetrievalError(Exception):
     pass

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -211,7 +211,7 @@ class WorkbookImporter:
                 else:
                     registry.add_submittables(metadata_entities)
             except Exception as e:
-                workbook_errors.append({"location": "File", "type": e.__class__.__name__, "detail": str(e)})
+                workbook_errors.append({"location": f'sheet={worksheet.title}', "type": e.__class__.__name__, "detail": str(e)})
 
         if registry.has_project():
             registry.import_modules()

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -31,11 +31,18 @@ def _create_single_row_worksheet(worksheet_data: dict):
 
 
 class WorkbookImporterTest(TestCase):
+    mock_json_schemas = [
+        {'name': 'project', 'properties': ['contributors']},
+        {'name': 'users', 'properties': ['sn_profiles']}
+    ]
 
     @patch('ingest.importer.importer.WorksheetImporter')
     def test_do_import(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users'])
+
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
@@ -73,6 +80,9 @@ class WorkbookImporterTest(TestCase):
     def test_do_import_with_module_tab(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users','users'])
+
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
@@ -131,6 +141,9 @@ class WorkbookImporterTest(TestCase):
     def test_do_import_project_worksheet(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(return_value='project')
+
         worksheet_importer = WorkbookImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
@@ -171,11 +184,14 @@ class WorkbookImporterTest(TestCase):
     def test_do_import_multiple_projects(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(return_value='project')
+
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
         expected_error = {
-            'location': 'File',
+            'location': 'sheet=Project',
             'type': 'MultipleProjectsFound',
             'detail': 'The spreadsheet should only be associated to a single project.'
         }

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -41,7 +41,7 @@ class WorkbookImporterTest(TestCase):
         # given:
         template_mgr = MagicMock(name='template_manager')
         template_mgr.template.json_schemas = self.mock_json_schemas
-        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users'])
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project', 'users'])
 
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
@@ -81,7 +81,7 @@ class WorkbookImporterTest(TestCase):
         # given:
         template_mgr = MagicMock(name='template_manager')
         template_mgr.template.json_schemas = self.mock_json_schemas
-        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users','users'])
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project', 'users', 'users'])
 
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer


### PR DESCRIPTION
A fix for [ingest-central#35](https://github.com/HumanCellAtlas/ingest-central/issues/35)

Not included the idea of warnings yet, I think that might need to wait until after the UI can show many more errors.

This change will raise an error if:
- the concrete type of the tab is not included in the schema list
- or the module type of the tab is not within the properties of the concrete schema