### PR TITLE
Raise Error when data would be ignored.

### DIFF
--- a/ingest/importer/conversion/metadata_entity.py
+++ b/ingest/importer/conversion/metadata_entity.py
@@ -86,17 +86,13 @@ class MetadataEntity:
             link_map[link_entity_type] = existent_links
         existent_links.extend(new_links)
 
-    def retain_intersecting_fields(self, *fields):
+    def retain_fields(self, *allowed_fields):
         for key in self._content.keys():
-            if key not in fields:
+            if key not in allowed_fields:
                 self._content.remove_field(key)
 
-    def list_non_intersecting_fields(self, fields):
-        non_intersecting_fields = []
-        for key in self._content.keys():
-            if key not in fields:
-                non_intersecting_fields.append({'key': key, 'value': self._content[key]})
-        return non_intersecting_fields
+    def list_fields(self, excluded_fields):
+        return [{'key': key, 'value': self._content[key]} for key in self._content.keys() if key not in excluded_fields]
 
     def add_module_entity(self, module_entity):
         for field, value in module_entity.content.as_dict().items():

--- a/ingest/importer/conversion/metadata_entity.py
+++ b/ingest/importer/conversion/metadata_entity.py
@@ -86,10 +86,17 @@ class MetadataEntity:
             link_map[link_entity_type] = existent_links
         existent_links.extend(new_links)
 
-    def retain_content_fields(self, *fields):
+    def retain_intersecting_fields(self, *fields):
         for key in self._content.keys():
             if key not in fields:
                 self._content.remove_field(key)
+
+    def list_non_intersecting_fields(self, fields):
+        non_intersecting_fields = []
+        for key in self._content.keys():
+            if key not in fields:
+                non_intersecting_fields.append({'key': key, 'value': self._content[key]})
+        return non_intersecting_fields
 
     def add_module_entity(self, module_entity):
         for field, value in module_entity.content.as_dict().items():

--- a/ingest/importer/conversion/template_manager.py
+++ b/ingest/importer/conversion/template_manager.py
@@ -15,6 +15,7 @@ from ingest.template.schema_template import SchemaTemplate
 
 
 class TemplateManager:
+    default_keys = ['describedBy', 'schema_type']
 
     def __init__(self, template: SchemaTemplate, ingest_api: IngestApi):
         self.template = template
@@ -25,8 +26,8 @@ class TemplateManager:
         concrete_entity = self.get_concrete_type(worksheet.title)
         schema = self._get_schema(concrete_entity)
         data_node = DataNode()
-        data_node['describedBy'] = schema['url']
-        data_node['schema_type'] = schema['domain_entity']
+        data_node[self.default_keys[0]] = schema['url']
+        data_node[self.default_keys[1]] = schema['domain_entity']
         return data_node
 
     def create_row_template(self, ingest_worksheet: IngestWorksheet):
@@ -63,8 +64,8 @@ class TemplateManager:
 
     def _define_default_values(self, object_type):
         default_values = {
-            'describedBy': self.get_schema_url(object_type),
-            'schema_type': self.get_domain_type(object_type)
+            self.default_keys[0]: self.get_schema_url(object_type),
+            self.default_keys[1]: self.get_domain_type(object_type)
         }
         return default_values
 

--- a/ingest/importer/conversion/template_manager.py
+++ b/ingest/importer/conversion/template_manager.py
@@ -180,7 +180,7 @@ class RowTemplate:
                 except Exception as e:
                     row_errors.append({"location": f'cell={index}, value={cell.value}', "type": e.__class__.__name__, "detail": str(e)})
         except Exception as e:
-            row_errors.append({"location": "", "type": e.__class__.__name__, "detail": str(e)})
+            row_errors.append({"type": e.__class__.__name__, "detail": str(e)})
         return metadata, row_errors
 
 

--- a/ingest/importer/conversion/template_manager.py
+++ b/ingest/importer/conversion/template_manager.py
@@ -158,7 +158,6 @@ def build(schemas, ingest_api) -> TemplateManager:
 
 
 class RowTemplate:
-
     def __init__(self, domain_type, object_type, cell_conversions, default_values={}):
         self.domain_type = domain_type
         self.concrete_type = object_type
@@ -167,20 +166,19 @@ class RowTemplate:
 
     def do_import(self, row: IngestRow):
         row_errors = []
-        metadata = None
-        try:
-            metadata = MetadataEntity(domain_type=self.domain_type, concrete_type=self.concrete_type,
-                                      content=self.default_values, row=row)
-            for index, cell in enumerate(row.values):
-                if cell.value is None:
-                    continue
-                try:
-                    conversion: CellConversion = self.cell_conversions[index]
-                    conversion.apply(metadata, cell.value)
-                except Exception as e:
-                    row_errors.append({"location": f'column={index}, value={cell.value}', "type": e.__class__.__name__, "detail": str(e)})
-        except Exception as e:
-            row_errors.append({"type": e.__class__.__name__, "detail": str(e)})
+        metadata = MetadataEntity(domain_type=self.domain_type, concrete_type=self.concrete_type,
+                                  content=self.default_values, row=row)
+        for index, cell in enumerate(row.values):
+            if cell.value is None:
+                continue
+            try:
+                conversion: CellConversion = self.cell_conversions[index]
+                conversion.apply(metadata, cell.value)
+            except Exception as e:
+                row_errors.append({
+                    "location": f'column={index}, value={cell.value}',
+                    "type": e.__class__.__name__, "detail": str(e)
+                })
         return metadata, row_errors
 
 

--- a/ingest/importer/conversion/template_manager.py
+++ b/ingest/importer/conversion/template_manager.py
@@ -178,7 +178,7 @@ class RowTemplate:
                     conversion: CellConversion = self.cell_conversions[index]
                     conversion.apply(metadata, cell.value)
                 except Exception as e:
-                    row_errors.append({"location": f'cell={index}, value={cell.value}', "type": e.__class__.__name__, "detail": str(e)})
+                    row_errors.append({"location": f'column={index}, value={cell.value}', "type": e.__class__.__name__, "detail": str(e)})
         except Exception as e:
             row_errors.append({"type": e.__class__.__name__, "detail": str(e)})
         return metadata, row_errors

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -305,7 +305,7 @@ class NoProjectFound(Exception):
 
 class SheetNotFoundInSchemas(Exception):
     def __init__(self, sheet):
-        message = f'The sheet {sheet} was not found in the list of schemas.'
+        message = f'The sheet named {sheet} was not found in the schema list.'
         super(SheetNotFoundInSchemas, self).__init__(message)
         self.sheet = sheet
 

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -211,7 +211,7 @@ class WorkbookImporter:
                 else:
                     registry.add_submittables(metadata_entities)
             except Exception as e:
-                workbook_errors.append({"location": "File", "type": e.__class__.__name__, "detail": str(e)})
+                workbook_errors.append({"location": f'sheet={worksheet.title}', "type": e.__class__.__name__, "detail": str(e)})
 
         if registry.has_project():
             registry.import_modules()
@@ -282,10 +282,12 @@ class NoProjectFound(Exception):
         message = f'The spreadsheet should be associated to a project.'
         super(NoProjectFound, self).__init__(message)
 
+
 class SheetNotFoundInSchemas(Exception):
     def __init__(self, sheet):
         message = f'The sheet {sheet} was not found in the list of schemas.'
         super(SheetNotFoundInSchemas, self).__init__(message)
+
 
 class SchemaRetrievalError(Exception):
     pass

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -140,10 +140,19 @@ class _ImportRegistry:
                 raise MultipleProjectsFound()
         type_map[metadata.object_id] = metadata
 
+    def add_submittables(self, metadata_entities):
+        for entity in metadata_entities:
+            self.add_submittable(entity)
+
     def add_module(self, metadata: MetadataEntity):
         if metadata.domain_type.lower() == 'project':
             metadata.object_id = self.project_id
         self._module_list.append(metadata)
+
+    def add_modules(self, metadata_entities, module_field_name):
+        for entity in metadata_entities:
+            entity.retain_content_fields(module_field_name)
+            self.add_module(entity)
 
     def import_modules(self):
         for module_entity in self._module_list:
@@ -197,12 +206,10 @@ class WorkbookImporter:
                         error["location"] = f'sheet={worksheet.title}'
                     workbook_errors.append(error)
 
-                for entity in metadata_entities:
-                    if worksheet.is_module_tab():
-                        entity.retain_content_fields(module_field_name)
-                        registry.add_module(entity)
-                    else:
-                        registry.add_submittable(entity)
+                if worksheet.is_module_tab():
+                    registry.add_modules(metadata_entities, module_field_name)
+                else:
+                    registry.add_submittables(metadata_entities)
             except Exception as e:
                 workbook_errors.append({"location": "File", "type": e.__class__.__name__, "detail": str(e)})
 

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -156,8 +156,8 @@ class _ImportRegistry:
         allowed_fields.extend(self.template_mgr.default_keys)
         removed_fields = []
         for entity in metadata_entities:
-            removed_fields.extend(entity.list_non_intersecting_fields(allowed_fields))
-            entity.retain_intersecting_fields(module_field_name)
+            removed_fields.extend(entity.list_fields(excluded_fields=allowed_fields))
+            entity.retain_fields(module_field_name)
             self.add_module(entity)
         return removed_fields
 

--- a/ingest/importer/importer.py
+++ b/ingest/importer/importer.py
@@ -151,7 +151,7 @@ class _ImportRegistry:
             metadata.object_id = self.project_id
         self._module_list.append(metadata)
 
-    def add_modules(self, metadata_entities, module_field_name):
+    def add_modules(self, module_field_name, metadata_entities):
         allowed_fields = [module_field_name]
         allowed_fields.extend(self.template_mgr.default_keys)
         removed_fields = []
@@ -214,7 +214,7 @@ class WorkbookImporter:
                     workbook_errors.append(error)
 
                 if worksheet.is_module_tab():
-                    removed_data = registry.add_modules(metadata_entities, module_field_name)
+                    removed_data = registry.add_modules(module_field_name, metadata_entities)
                     workbook_errors.extend(self.list_data_removal_errors(worksheet.title, removed_data))
                 else:
                     registry.add_submittables(metadata_entities)

--- a/ingest/importer/spreadsheet/ingest_workbook.py
+++ b/ingest/importer/spreadsheet/ingest_workbook.py
@@ -12,10 +12,10 @@ class IngestWorkbook:
         self.workbook = workbook
 
     def get_worksheet(self, worksheet_title):
-        if worksheet_title in self.workbook.get_sheet_names():
+        if worksheet_title in self.workbook.sheetnames:
             return self.workbook[worksheet_title]
 
-        if worksheet_title.lower() in self.workbook.get_sheet_names():
+        if worksheet_title.lower() in self.workbook.sheetnames:
             return self.workbook[worksheet_title.lower()]
 
         return None
@@ -25,11 +25,11 @@ class IngestWorkbook:
 
         worksheet = None
 
-        if SCHEMAS_WORKSHEET in self.workbook.get_sheet_names():
-            worksheet = self.workbook.get_sheet_by_name(SCHEMAS_WORKSHEET)
+        if SCHEMAS_WORKSHEET in self.workbook.sheetnames:
+            worksheet = self.workbook[SCHEMAS_WORKSHEET]
 
-        if SCHEMAS_WORKSHEET.lower() in self.workbook.get_sheet_names():
-            worksheet = self.workbook.get_sheet_by_name(SCHEMAS_WORKSHEET.lower())
+        if SCHEMAS_WORKSHEET.lower() in self.workbook.sheetnames:
+            worksheet = self.workbook[SCHEMAS_WORKSHEET.lower()]
 
         if not worksheet:
             return schemas

--- a/ingest/template/schema_template.py
+++ b/ingest/template/schema_template.py
@@ -328,7 +328,7 @@ class SchemaTemplate:
         try:
             return self.tab_config.get_key_for_label(label)
         except KeyError:
-            raise UnknownKeySchemaException(f'No key found for [{label}].')
+            raise UnknownKeySchemaException(f'Tab [{label}] is not recognised.')
 
     def _get_level_one(self, key):
         return key.split('.')[0]

--- a/tests/importer/conversion/test_metadata_entity.py
+++ b/tests/importer/conversion/test_metadata_entity.py
@@ -101,7 +101,7 @@ class MetadataEntityTest(TestCase):
         metadata_entity = MetadataEntity(domain_type='user', concrete_type='user', object_id=1,
                                          content=content)
         # when:
-        metadata_entity.retain_content_fields('user_name')
+        metadata_entity.retain_intersecting_fields('user_name')
 
         # then:
         self.assertEqual(['user_name'], list(metadata_entity.content.as_dict().keys()))

--- a/tests/importer/conversion/test_metadata_entity.py
+++ b/tests/importer/conversion/test_metadata_entity.py
@@ -101,7 +101,7 @@ class MetadataEntityTest(TestCase):
         metadata_entity = MetadataEntity(domain_type='user', concrete_type='user', object_id=1,
                                          content=content)
         # when:
-        metadata_entity.retain_intersecting_fields('user_name')
+        metadata_entity.retain_fields('user_name')
 
         # then:
         self.assertEqual(['user_name'], list(metadata_entity.content.as_dict().keys()))

--- a/tests/importer/conversion/test_template_manager.py
+++ b/tests/importer/conversion/test_template_manager.py
@@ -173,7 +173,7 @@ class TemplateManagerTest(TestCase):
 
         # and:
         workbook = create_test_workbook('Product - Reviews')
-        reviews_worksheet = workbook.get_sheet_by_name('Product - Reviews')
+        reviews_worksheet = workbook['Product - Reviews']
         reviews_worksheet['A4'] = 'product.info.id'
         reviews_worksheet['B4'] = 'product.reviews.rating'
 

--- a/tests/importer/spreadsheet/test_ingest_worksheet.py
+++ b/tests/importer/spreadsheet/test_ingest_worksheet.py
@@ -10,8 +10,8 @@ class IngestWorksheetTest(TestCase):
     def test_get_title(self):
         # given:
         workbook = create_test_workbook('User', 'User - SN Profiles')
-        user_sheet = workbook.get_sheet_by_name('User')
-        sn_profiles_sheet = workbook.get_sheet_by_name('User - SN Profiles')
+        user_sheet = workbook['User']
+        sn_profiles_sheet = workbook['User - SN Profiles']
 
         # and:
         user = IngestWorksheet(user_sheet)
@@ -139,8 +139,8 @@ class IngestWorksheetTest(TestCase):
     def test_is_module_tab(self):
         # given:
         workbook = create_test_workbook('Product', 'Product - History')
-        product_sheet = workbook.get_sheet_by_name('Product')
-        history_sheet = workbook.get_sheet_by_name('Product - History')
+        product_sheet = workbook['Product']
+        history_sheet = workbook['Product - History']
 
         # and:
         product = IngestWorksheet(product_sheet)
@@ -156,19 +156,19 @@ class IngestWorksheetTest(TestCase):
                                         'Log - file-names', 'Account')
 
         # and: simple
-        reviews_sheet = workbook.get_sheet_by_name('Product - Reviews')
+        reviews_sheet = workbook['Product - Reviews']
         reviews = IngestWorksheet(reviews_sheet)
 
         # and: with space in between
-        sn_profiles_sheet = workbook.get_sheet_by_name('User - SN Profiles')
+        sn_profiles_sheet = workbook['User - SN Profiles']
         sn_profiles = IngestWorksheet(sn_profiles_sheet)
 
         # and: with hyphen
-        file_names_sheet = workbook.get_sheet_by_name('Log - file-names')
+        file_names_sheet = workbook['Log - file-names']
         file_names = IngestWorksheet(file_names_sheet)
 
         # and: not module worksheet
-        account_sheet = workbook.get_sheet_by_name('Account')
+        account_sheet = workbook['Account']
         account = IngestWorksheet(account_sheet)
 
         # expect:

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -31,11 +31,18 @@ def _create_single_row_worksheet(worksheet_data: dict):
 
 
 class WorkbookImporterTest(TestCase):
+    mock_json_schemas = [
+        {'name': 'project', 'properties': ['contributors']},
+        {'name': 'users', 'properties': ['sn_profiles']}
+    ]
 
     @patch('ingest.importer.importer.WorksheetImporter')
     def test_do_import(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users'])
+
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
@@ -73,6 +80,9 @@ class WorkbookImporterTest(TestCase):
     def test_do_import_with_module_tab(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users','users'])
+
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
@@ -131,6 +141,9 @@ class WorkbookImporterTest(TestCase):
     def test_do_import_project_worksheet(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(return_value='project')
+
         worksheet_importer = WorkbookImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
@@ -171,11 +184,14 @@ class WorkbookImporterTest(TestCase):
     def test_do_import_multiple_projects(self, worksheet_importer_constructor):
         # given:
         template_mgr = MagicMock(name='template_manager')
+        template_mgr.template.json_schemas = self.mock_json_schemas
+        template_mgr.get_concrete_type = MagicMock(return_value='project')
+
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
         no_errors = []
         expected_error = {
-            'location': 'File',
+            'location': 'sheet=Project',
             'type': 'MultipleProjectsFound',
             'detail': 'The spreadsheet should only be associated to a single project.'
         }

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -92,10 +92,15 @@ class WorkbookImporterTest(TestCase):
                               content={'user_name': 'janedoe'})
         fb_profile = MetadataEntity(concrete_type='sn_profile', domain_type='user', object_id=773,
                                     content={'sn_profiles': {'name': 'facebook', 'id': '392'},
-                                             'description': 'extra field'})
+                                             'description': 'extra fb field'})
         ig_profile = MetadataEntity(concrete_type='sn_profile', domain_type='user', object_id=773,
                                     content={'sn_profiles': {'name': 'instagram', 'id': 'a92'},
-                                             'description': 'extra field'})
+                                             'description': 'extra ig field'})
+        expected_errors = [
+            {'key': 'description', 'value': 'extra fb field'},
+            {'key': 'description', 'value': 'extra ig field'}
+        ]
+
         worksheet_importer.do_import = MagicMock(side_effect=[
             ([project], no_errors),
             ([user], no_errors),
@@ -111,7 +116,7 @@ class WorkbookImporterTest(TestCase):
 
         # then:
         self.assertIsNotNone(spreadsheet_json)
-        self.assertEqual(errors, [])
+        self.assertEqual(errors, workbook_importer.list_data_removal_errors('User - SN Profiles', expected_errors))
         self.assertEqual(2, len(spreadsheet_json))
 
         # and:

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -41,7 +41,7 @@ class WorkbookImporterTest(TestCase):
         # given:
         template_mgr = MagicMock(name='template_manager')
         template_mgr.template.json_schemas = self.mock_json_schemas
-        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users'])
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project', 'users'])
 
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer
@@ -81,7 +81,7 @@ class WorkbookImporterTest(TestCase):
         # given:
         template_mgr = MagicMock(name='template_manager')
         template_mgr.template.json_schemas = self.mock_json_schemas
-        template_mgr.get_concrete_type = MagicMock(side_effect=['project','users','users'])
+        template_mgr.get_concrete_type = MagicMock(side_effect=['project', 'users', 'users'])
 
         worksheet_importer = WorksheetImporter(template_mgr)
         worksheet_importer_constructor.return_value = worksheet_importer


### PR DESCRIPTION
A fix for [ingest-central#35](https://github.com/HumanCellAtlas/ingest-central/issues/35)

Not included the idea of warnings yet, I think that might need to wait until after the UI can show many more errors.

This change will raise an error if:
- the concrete type of the tab is not included in the schema list
- or the module type of the tab is not within the properties of the concrete schema
- Any data is not converted to JSON, usually because the column name does not match the module name.