### PR TITLE
Removing extraneous tests.

### DIFF
--- a/ingest/template/descriptor.py
+++ b/ingest/template/descriptor.py
@@ -111,6 +111,9 @@ class ComplexPropertyDescriptor(SimplePropertyDescriptor, Descriptor):
             for property_name, property_values in json_data["properties"].items():
                 if "$schema" in property_values or "schema" in property_values:
                     child_property_descriptor = ComplexPropertyDescriptor(property_values)
+                elif "items" in property_values and ("$schema" in property_values["items"] or "schema" in property_values["items"]):
+                    child_property_descriptor = ComplexPropertyDescriptor(property_values["items"])
+                    child_property_descriptor.multivalue = True
                 else:
                     child_property_descriptor = SimplePropertyDescriptor(property_values)
 

--- a/ingest/template/new_schema_template.py
+++ b/ingest/template/new_schema_template.py
@@ -122,7 +122,6 @@ class NewSchemaTemplate():
         :param property_key: A string representing the fully qualified path to the desired metadata property
         :return: A dictionary representing the attributes of the property. If none is found, an exception will be thrown
         """
-
         return self._lookup_fully_qualified_key_path_in_dictionary(property_key, self.meta_data_properties)
 
     def lookup_metadata_schema_name_given_title(self, tab_display_name):

--- a/ingest/template/spreadsheet_builder.py
+++ b/ingest/template/spreadsheet_builder.py
@@ -36,7 +36,8 @@ class SpreadsheetBuilder():
     def save_spreadsheet(self):
         self.spreadsheet.close()
 
-    def generate_spreadsheet(self, schema_urls=None, tabs_template=None, include_schemas_tab=False):
+    def generate_spreadsheet(self, schema_urls=None, tabs_template=None, include_schemas_tab=False,
+                             schema_template=None):
         """
         Given a template that represents the tabs configuration in the desired spreadsheet and a metadata schema,
         generates the respective spreadsheet. If include_schema_tab is set to True, the spreadsheet will have an
@@ -48,6 +49,8 @@ class SpreadsheetBuilder():
                               the generated spreadsheet should look and what information/columns it should contain.
         :param include_schemas_tab: A boolean, when true, includes an additional sheet at the end of the spreadsheet
                                     that contains a list of metadata schemas that were used to create the spreadsheet.
+        :param schema_template: A SchemaTemplate object that has already been created that can directly be used to
+                                generate the spreadsheet.
         """
 
         self.include_schemas_tab = include_schemas_tab
@@ -57,6 +60,8 @@ class SpreadsheetBuilder():
             template = NewSchemaTemplate(metadata_schema_urls=schema_urls, tab_config=tabs)
         elif schema_urls:
             template = NewSchemaTemplate(metadata_schema_urls=schema_urls, migrations_url=DEFAULT_MIGRATIONS_URL)
+        elif schema_template:
+            template = schema_template
         else:
             template = NewSchemaTemplate()
 

--- a/tests/template/test_descriptor.py
+++ b/tests/template/test_descriptor.py
@@ -6,65 +6,6 @@ from ingest.template.descriptor import ComplexPropertyDescriptor, SchemaTypeDesc
 class TestDescriptor(unittest.TestCase):
     """ Testing class for the Descriptor class. """
 
-    def test_custom_location_support(self):
-        sample_metadata_schema_url = "https://humancellatlas.org/schema/type/protocol/sequencing/10.1.0" \
-                                     "/sequencing_protocol"
-
-        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
-
-        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
-                                              "module": "sequencing_protocol", "version": "10.1.0",
-                                              "url": sample_metadata_schema_url}
-        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
-                         expected_dictionary_representation)
-
-    def test_domain_entity_containing_slash_support(self):
-        sample_metadata_schema_url = "https://schema.humancellatlas.org/type/protocol/sequencing/10.1.0" \
-                                     "/sequencing_protocol"
-
-        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
-
-        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
-                                              "module": "sequencing_protocol", "version": "10.1.0",
-                                              "url": sample_metadata_schema_url}
-        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
-                         expected_dictionary_representation)
-
-    def test_version_entity_has_major(self):
-        sample_metadata_schema_url = "https://schema.humancellatlas.org/type/protocol/sequencing/10/sequencing_protocol"
-
-        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
-
-        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
-                                              "module": "sequencing_protocol", "version": "10",
-                                              "url": sample_metadata_schema_url}
-        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
-                         expected_dictionary_representation)
-
-    def test_version_entity_has_major_minor(self):
-        sample_metadata_schema_url = "https://schema.humancellatlas.org/type/protocol/sequencing/10.1" \
-                                     "/sequencing_protocol"
-
-        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
-
-        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
-                                              "module": "sequencing_protocol", "version": "10.1",
-                                              "url": sample_metadata_schema_url}
-        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
-                         expected_dictionary_representation)
-
-    def test_version_entity_has_major_minor_revision(self):
-        sample_metadata_schema_url = "https://schema.humancellatlas.org/type/protocol/sequencing/10.1.5" \
-                                     "/sequencing_protocol"
-
-        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
-
-        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
-                                              "module": "sequencing_protocol", "version": "10.1.5",
-                                              "url": sample_metadata_schema_url}
-        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
-                         expected_dictionary_representation)
-
     def test__schema_type_descriptor__success(self):
         sample_metadata_schema_url = "https://schema.humancellatlas.org/type/biomaterial/10.0.2/organoid"
 
@@ -81,6 +22,45 @@ class TestDescriptor(unittest.TestCase):
 
         with self.assertRaisesRegex(Exception, "does not conform to expected format"):
             SchemaTypeDescriptor(sample_metadata_schema_url)
+
+    def test__schema_type_descriptor_additional_slashes__succeeds(self):
+        sample_metadata_schema_url = "https://humancellatlas.org/schema/type/protocol/sequencing/10.1.0" \
+                                     "/sequencing_protocol"
+
+        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
+
+        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
+                                              "module": "sequencing_protocol", "version": "10.1.0",
+                                              "url": sample_metadata_schema_url}
+        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
+                         expected_dictionary_representation)
+
+    def test__schema_type_descriptor_with_domain_entity_containing_slash__succeeds(self):
+        sample_metadata_schema_url = "https://schema.humancellatlas.org/type/protocol/sequencing/10.1.0" \
+                                     "/sequencing_protocol"
+
+        descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
+
+        expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
+                                              "module": "sequencing_protocol", "version": "10.1.0",
+                                              "url": sample_metadata_schema_url}
+        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
+                         expected_dictionary_representation)
+
+    def test__schema_type_descriptor_permutations_of_versioning__succeeds(self):
+        version_formats_to_test = ["10", "10.1", "10.1.5"]
+
+        for version_format in version_formats_to_test:
+            sample_metadata_schema_url = "https://schema.humancellatlas.org/type/protocol/sequencing/" + \
+                                         version_format + "/sequencing_protocol"
+
+            descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
+
+            expected_dictionary_representation = {"high_level_entity": "type", "domain_entity": "protocol/sequencing",
+                                                  "module": "sequencing_protocol", "version": version_format,
+                                                  "url": sample_metadata_schema_url}
+            self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
+                             expected_dictionary_representation)
 
     def test__simple_property_descriptor__success(self):
         sample_simple_property_description = "The version number of the schema in major.minor.patch format."

--- a/tests/template/test_descriptor.py
+++ b/tests/template/test_descriptor.py
@@ -6,7 +6,7 @@ from ingest.template.descriptor import ComplexPropertyDescriptor, SchemaTypeDesc
 class TestDescriptor(unittest.TestCase):
     """ Testing class for the Descriptor class. """
 
-    def test__schema_type_descriptor__success(self):
+    def test__schema_type_descriptor__succeeds(self):
         sample_metadata_schema_url = "https://schema.humancellatlas.org/type/biomaterial/10.0.2/organoid"
 
         descriptor = SchemaTypeDescriptor(sample_metadata_schema_url)
@@ -62,7 +62,7 @@ class TestDescriptor(unittest.TestCase):
             self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(),
                              expected_dictionary_representation)
 
-    def test__simple_property_descriptor__success(self):
+    def test__simple_property_descriptor__succeeds(self):
         sample_simple_property_description = "The version number of the schema in major.minor.patch format."
         sample_simple_property_type = "string"
         sample_simple_property_pattern = "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$"
@@ -84,7 +84,7 @@ class TestDescriptor(unittest.TestCase):
         }
         self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(), expected_dictionary_representation)
 
-    def test__simple_array_property_descriptor__success(self):
+    def test__simple_array_property_descriptor__succeeds(self):
         sample_simple_property_description = "The version number of the schema in major.minor.patch format."
         sample_simple_property_type = "array"
         sample_simple_property_pattern = "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$"
@@ -109,7 +109,7 @@ class TestDescriptor(unittest.TestCase):
         }
         self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(), expected_dictionary_representation)
 
-    def test__complex_property_description__success(self):
+    def test__complex_property_description__succeeds(self):
         top_level_metadata_schema_url = "https://schema.humancellatlas.org/module/biomaterial/2.0.2/timecourse"
         sample_complex_metadata_schema_json = {
             "$schema": "http://json-schema.org/draft-07/schema#",
@@ -165,7 +165,7 @@ class TestDescriptor(unittest.TestCase):
         expected_dictionary_representation.update(expected_top_level_schema_properties)
         self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(), expected_dictionary_representation)
 
-    def test__complex_property_description_with_embedded_schema__success(self):
+    def test__complex_property_description_with_embedded_schema__succeeds(self):
         top_level_metadata_schema_url = "https://schema.humancellatlas.org/module/biomaterial/2.0.2/timecourse"
         embedded_metadata_schema_url = "https://schema.humancellatlas.org/module/ontology/5.3.5/time_unit_ontology"
         sample_complex_metadata_schema_json = {
@@ -270,77 +270,7 @@ class TestDescriptor(unittest.TestCase):
         expected_dictionary_representation.update(expected_top_level_schema_properties)
         self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(), expected_dictionary_representation)
 
-    def test__complex_property_description_with_multivalue_embedded_schema__success(self):
-        top_level_metadata_schema_url = "https://schema.humancellatlas.org/module/biomaterial/2.0.2/some_schema"
-        embedded_metadata_schema_url = "https://schema.humancellatlas.org/module/biomaterial/5.3.5/some_embedded_schema"
-        sample_complex_metadata_schema_json = {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "$id": top_level_metadata_schema_url,
-            "description": "Information relating to a schema.",
-            "required": [
-                "some_multivalue_property"
-            ],
-            "type": "object",
-            "properties": {
-                "some_multivalue_property": {
-                    "description": "A multivalue property",
-                    "type": "array",
-                    "items": {
-                        "$schema": "http://json-schema.org/draft-07/schema#",
-                        "$id": embedded_metadata_schema_url,
-                        "description": "A multivalue property",
-                        "type": "object",
-                        "properties": {
-                            "some_embedded_schema_property": {
-                                "description": "Some embedded schema property",
-                                "type": "string",
-                            }
-                        }
-                    }
-                },
-            }
-        }
-
-        descriptor = ComplexPropertyDescriptor(sample_complex_metadata_schema_json)
-
-        # Create the expected dictionary representation of the embedded schema property.
-        expected_embedded_schema_descriptor = {
-            "high_level_entity": "module", "domain_entity": "biomaterial", "module": "some_embedded_schema",
-            "version": "5.3.5", "url": embedded_metadata_schema_url
-        }
-        expected_embedded_schema_properties = {
-            "description": "A multivalue property", "value_type": "object", "multivalue": True,
-            "external_reference": False, "required": True, "identifiable": False
-        }
-        expected_embedded_child_property_descriptor = {
-            "description": "Some embedded schema property", "value_type": "string", "multivalue": False,
-            "external_reference": False, "required": False, "identifiable": False
-        }
-        expected_child_property_descriptor = {
-            "schema": expected_embedded_schema_descriptor,
-            "some_embedded_schema_property": expected_embedded_child_property_descriptor
-        }
-        expected_child_property_descriptor.update(expected_embedded_schema_properties)
-
-        # Create the top level expected dictionary representation
-        expected_top_level_schema_descriptor = {
-            "high_level_entity": "module", "domain_entity": "biomaterial", "module": "some_schema", "version": "2.0.2",
-            "url": top_level_metadata_schema_url
-        }
-        expected_top_level_schema_properties = {
-            "description": "Information relating to a schema.", "value_type": "object", "multivalue": False,
-            "external_reference": False, "required": False, "identifiable": False
-        }
-        expected_dictionary_representation = {
-            "schema": expected_top_level_schema_descriptor,
-            "some_multivalue_property": expected_child_property_descriptor,
-            "required_properties": ["some_multivalue_property"]
-        }
-        expected_dictionary_representation.update(expected_top_level_schema_properties)
-
-        self.assertEqual(descriptor.get_dictionary_representation_of_descriptor(), expected_dictionary_representation)
-
-    def test__complex_identifiable_property_descriptor__success(self):
+    def test__complex_identifiable_property_descriptor__succeeds(self):
         top_level_metadata_schema_url = "https://schema.humancellatlas.org/module/biomaterial/2.0.2/timecourse"
         sample_complex_metadata_schema_json = {
             "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
The tests that have been added to the descriptor test file are exactly the same as `test__schema_type_descriptor__success` and therefore do not test any novel code path. To keep it clean, removing the extraneous tests.