### PR TITLE
Use dcpVersion instead of updateDate for DSS bundle file content and version

### DIFF
--- a/ingest/exporter/ingestexportservice.py
+++ b/ingest/exporter/ingestexportservice.py
@@ -350,7 +350,7 @@ class IngestExporter:
                     'dss_filename': file_name,
                     'dss_uuid': metadata_uuid,
                     'upload_filename': upload_filename,
-                    'update_date': doc['updateDate'],
+                    'update_date': doc['dcpVersion'],
                     'is_from_input_bundle': self._is_from_input_bundle(entity_type, metadata_uuid,
                                                                        process_info.input_bundle)
                 }
@@ -375,7 +375,7 @@ class IngestExporter:
         provenance_core = dict()
         provenance_core['document_id'] = uuid
         provenance_core['submission_date'] = metadata_doc['submissionDate']
-        provenance_core['update_date'] = metadata_doc['updateDate']
+        provenance_core['update_date'] = metadata_doc['dcpVersion']
 
         # Populate the major and minor schema versions from the URL in the describedBy field
         schema_semver = re.findall(r'\d+\.\d+\.\d+', metadata_doc["content"]["describedBy"])[0]

--- a/ingest/exporter/metadata.py
+++ b/ingest/exporter/metadata.py
@@ -57,7 +57,7 @@ class MetadataResource:
         try:
             uuid = data['uuid']['uuid']
             submission_date = data['submissionDate']
-            update_date = data['updateDate']
+            update_date = data['dcpVersion']
 
             # Populate the major and minor schema versions from the URL in the describedBy field
             schema_semver = re.findall(r'\d+\.\d+\.\d+', data["content"]["describedBy"])[0]

--- a/tests/exporter/test_ingestexportservice.py
+++ b/tests/exporter/test_ingestexportservice.py
@@ -52,7 +52,7 @@ class TestExporter(TestCase):
         with open(file_path) as f:
             sample_metadata_json = json.load(f)
         sample_metadata_json["submissionDate"] = arbitrary_submission_date
-        sample_metadata_json["updateDate"] = arbitrary_update_date
+        sample_metadata_json["dcpVersion"] = arbitrary_update_date
         sample_metadata_json["content"]["describedBy"] = arbitrary_schema_url
 
         # Execute test

--- a/tests/exporter/test_metadata.py
+++ b/tests/exporter/test_metadata.py
@@ -14,6 +14,7 @@ class MetadataResourceTest(TestCase):
             'uuid': {'uuid': uuid_value},
             'submissionDate': 'a submission date',
             'updateDate': 'an update date',
+            'dcpVersion': '2019-12-02T13:40:50.520Z',
             'content': {
                 'describedBy': 'https://some-schema/1.2.3'
             }
@@ -26,7 +27,7 @@ class MetadataResourceTest(TestCase):
         self.assertIsNotNone(metadata_provenance)
         self.assertEqual(uuid_value, metadata_provenance.document_id)
         self.assertEqual('a submission date', metadata_provenance.submission_date)
-        self.assertEqual('an update date', metadata_provenance.update_date)
+        self.assertEqual('2019-12-02T13:40:50.520Z', metadata_provenance.update_date)
 
     def test_provenance_from_dict_fail_fast(self):
         # given:
@@ -155,7 +156,7 @@ class MetadataServiceTest(TestCase):
                         'uuid': {'uuid': uuid},
                         'content': {'describedBy': "http://some-schema/1.2.3",
                                     'some': {'content': ['we', 'are', 'agnostic', 'of']}},
-                        'dcpVersion': '8.2.7',
+                        'dcpVersion': '2019-12-02T13:40:50.520Z',
                         'submissionDate': 'a submission date',
                         'updateDate': 'an update date'
                         }
@@ -174,4 +175,4 @@ class MetadataServiceTest(TestCase):
         self.assertEqual(raw_metadata['content'], metadata_resource.metadata_json)
         self.assertEqual(raw_metadata['dcpVersion'], metadata_resource.dcp_version)
         self.assertEqual(raw_metadata['submissionDate'], metadata_resource.provenance.submission_date)
-        self.assertEqual(raw_metadata['updateDate'], metadata_resource.provenance.update_date)
+        self.assertEqual(raw_metadata['dcpVersion'], metadata_resource.provenance.update_date)


### PR DESCRIPTION
Fixes humancellatlas/ingest-central/647 , humancellatlas/ingest-central/598

The dcpVersion gets populated when the user submits the submission. This should be used as the DSS file version and not the updateDate. The updateDate gets updated when dbref link is updated in Ingest (e.g. we link a new specimen to an existing donor). 

When a user added new metadata and link those to existing entities, we don't want a newer version for those existing entities as there are no changes to the content/json of those existing entities. We just want to create new bundles which reference those existing entities/files(same uuid + version).